### PR TITLE
update: add UtilsRL.env.wrapper as default wrapper module

### DIFF
--- a/wiserl/env/__init__.py
+++ b/wiserl/env/__init__.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional
 
 import gym
 from gym.envs import register
+import UtilsRL.env.wrapper
 
 from .base import EmptyEnv
 
@@ -34,5 +35,5 @@ def get_env(
         env = gym.make(env, **env_kwargs)
     if wrapper_class is not None:
         wrapper_kwargs = wrapper_kwargs or {}
-        env = vars()[wrapper_class](env, **wrapper_kwargs)
+        env = vars(UtilsRL.env.wrapper)[wrapper_class](env, **wrapper_kwargs)
     return env


### PR DESCRIPTION
We can change the env wrapper in config file with

```yaml
env: HalfCheetah-v3
env_kwargs:
env_wrapper: MujocoParamOverWrite
env_wrapper_kwargs:
  overwrite_args:
    gravity: 0.8
  do_scale: True
```

I'm not sure if it's correct, please check.