### PR TITLE
feat: add `use_placeholder` for easier configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 out/
 wandb
 tests/
+/datasets
 datasets/
 shells/
 ckpts

--- a/scripts/configs/bt_awac/adroit.yaml
+++ b/scripts/configs/bt_awac/adroit.yaml
@@ -45,7 +45,7 @@ network:
 
 rm_dataset:
   - class: IPLComparisonOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 8
     segment_length: null
     mode: human
@@ -55,7 +55,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: D4RLOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 256
     mode: transition
     reward_normalize: true
@@ -76,7 +76,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: IPLComparisonOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 32
     mode: human
     eval: false

--- a/scripts/configs/bt_awac/gym.yaml
+++ b/scripts/configs/bt_awac/gym.yaml
@@ -45,7 +45,7 @@ network:
 
 rm_dataset:
   - class: IPLComparisonOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 8
     segment_length: null
     mode: human
@@ -55,7 +55,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: D4RLOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 256
     mode: transition
     reward_normalize: true
@@ -76,7 +76,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: IPLComparisonOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 32
     mode: human
     eval: false

--- a/scripts/configs/bt_awac/metaworld.yaml
+++ b/scripts/configs/bt_awac/metaworld.yaml
@@ -45,7 +45,7 @@ network:
 
 rm_dataset:
   - class: MetaworldComparisonDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16
     segment_length: null
     capacity: 500
@@ -55,7 +55,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: MetaworldOfflineDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16
     capacity: 5000
 rl_dataloader:
@@ -75,7 +75,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: MetaworldComparisonDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 32
     segment_length: null
     capacity: 500

--- a/scripts/configs/bt_awac/metaworld/state_dense.yaml
+++ b/scripts/configs/bt_awac/metaworld/state_dense.yaml
@@ -46,7 +46,7 @@ network:
 
 dataset:
   class: MetaworldComparisonOfflineDataset
-  env: mw_drawer-open-v2
+  env: <env>
   label_key: rl_sum
   segment_length: null
   batch_size: 96

--- a/scripts/configs/bt_awac/metaworld/state_sparse.yaml
+++ b/scripts/configs/bt_awac/metaworld/state_sparse.yaml
@@ -46,7 +46,7 @@ network:
 
 dataset:
   class: MetaworldComparisonOfflineDataset
-  env: mw_drawer-open-v2
+  env: <env>
   label_key: rl_sum
   segment_length: null
   batch_size: 96

--- a/scripts/configs/bt_iql/adroit/default.yaml
+++ b/scripts/configs/bt_iql/adroit/default.yaml
@@ -50,7 +50,7 @@ network:
 
 rm_dataset:
   - class: IPLComparisonOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 8
     segment_length: null
     mode: human
@@ -60,7 +60,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: D4RLOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 256
     mode: transition
     reward_normalize: true
@@ -81,7 +81,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: IPLComparisonOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 32
     mode: human
     eval: false

--- a/scripts/configs/bt_iql/gym/default.yaml
+++ b/scripts/configs/bt_iql/gym/default.yaml
@@ -50,7 +50,7 @@ network:
 
 rm_dataset:
   - class: IPLComparisonOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 8
     segment_length: null
     mode: human
@@ -60,7 +60,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: D4RLOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 256
     mode: transition
     reward_normalize: true
@@ -81,7 +81,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: IPLComparisonOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 32
     mode: human
     eval: false

--- a/scripts/configs/bt_iql/metaworld/default.yaml
+++ b/scripts/configs/bt_iql/metaworld/default.yaml
@@ -54,7 +54,7 @@ network:
 
 rm_dataset:
   - class: MetaworldComparisonDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16
     segment_length: null
     capacity: 500
@@ -64,7 +64,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: MetaworldOfflineDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16
     capacity: 5000
 rl_dataloader:
@@ -84,7 +84,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: MetaworldComparisonDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 32
     segment_length: null
     capacity: 500

--- a/scripts/configs/bt_iql/metaworld/state_dense.yaml
+++ b/scripts/configs/bt_iql/metaworld/state_dense.yaml
@@ -51,7 +51,7 @@ network:
 
 dataset:
   class: MetaworldComparisonOfflineDataset
-  env: mw_drawer-open-v2
+  env: <env>
   label_key: rl_sum
   segment_length: null
   batch_size: 96

--- a/scripts/configs/bt_iql/metaworld/state_sparse.yaml
+++ b/scripts/configs/bt_iql/metaworld/state_sparse.yaml
@@ -51,7 +51,7 @@ network:
 
 dataset:
   class: MetaworldComparisonOfflineDataset
-  env: mw_drawer-open-v2
+  env: <env>
   label_key: rl_sum
   segment_length: null
   batch_size: 96

--- a/scripts/configs/cpl/metaworld/state_dense.yaml
+++ b/scripts/configs/cpl/metaworld/state_dense.yaml
@@ -39,7 +39,7 @@ network:
 
 dataset:
   class: MetaworldComparisonOfflineDataset
-  env: mw_drawer-open-v2
+  env: <env>
   label_key: rl_sum
   segment_length: null
   batch_size: 96

--- a/scripts/configs/cpl/metaworld/state_sparse.yaml
+++ b/scripts/configs/cpl/metaworld/state_sparse.yaml
@@ -39,7 +39,7 @@ network:
 
 dataset:
   class: MetaworldComparisonOfflineDataset
-  env: mw_drawer-open-v2
+  env: <env>
   label_key: rl_sum
   segment_length: null
   batch_size: 96

--- a/scripts/configs/cpl_kl/metaworld/state_dense.yaml
+++ b/scripts/configs/cpl_kl/metaworld/state_dense.yaml
@@ -38,7 +38,7 @@ network:
 
 dataset:
   class: MetaworldComparisonOfflineDataset
-  env: mw_drawer-open-v2
+  env: <env>
   label_key: rl_sum
   segment_length: null
   batch_size: 96

--- a/scripts/configs/cpl_kl/metaworld/state_sparse.yaml
+++ b/scripts/configs/cpl_kl/metaworld/state_sparse.yaml
@@ -38,7 +38,7 @@ network:
 
 dataset:
   class: MetaworldComparisonOfflineDataset
-  env: mw_drawer-open-v2
+  env: <env>
   label_key: rl_sum
   segment_length: null
   batch_size: 96

--- a/scripts/configs/hpl/adroit.yaml
+++ b/scripts/configs/hpl/adroit.yaml
@@ -76,17 +76,17 @@ network:
 
 rm_dataset:
   - class: D4RLOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 64 # [64, 128]
     mode: trajectory
     segment_length: 100
     padding_mode: none
   - class: IPLComparisonOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 8
     mode: human
   - class: D4RLOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 512
     mode: transition
 rm_dataloader:
@@ -95,7 +95,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: D4RLOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 512
     mode: transition
 rl_dataloader:
@@ -115,7 +115,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: IPLComparisonOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 32
     mode: human
     eval: false

--- a/scripts/configs/hpl/default.yaml
+++ b/scripts/configs/hpl/default.yaml
@@ -74,17 +74,17 @@ network:
 
 dataset:
   - class: D4RLOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 64 # [64, 128]
     mode: trajectory
     segment_length: 100
     padding_mode: none
   - class: IPLComparisonOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 8
     mode: human
   - class: D4RLOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 6400
     mode: transition
 

--- a/scripts/configs/hpl/discrete/adroit.yaml
+++ b/scripts/configs/hpl/discrete/adroit.yaml
@@ -79,17 +79,17 @@ network:
 
 rm_dataset:
   - class: D4RLOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 64 # [64, 128]
     mode: trajectory
     segment_length: 100
     padding_mode: none
   - class: IPLComparisonOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 8
     mode: human
   - class: D4RLOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 512
     mode: transition
 rm_dataloader:
@@ -98,7 +98,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: D4RLOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 512
     mode: transition
 rl_dataloader:
@@ -118,7 +118,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: IPLComparisonOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 32
     mode: human
     eval: false

--- a/scripts/configs/hpl/discrete/gym.yaml
+++ b/scripts/configs/hpl/discrete/gym.yaml
@@ -79,17 +79,17 @@ network:
 
 rm_dataset:
   - class: D4RLOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 64 # [64, 128]
     mode: trajectory
     segment_length: 100
     padding_mode: none
   - class: IPLComparisonOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 8
     mode: human
   - class: D4RLOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 512
     mode: transition
 rm_dataloader:
@@ -98,7 +98,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: D4RLOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 512
     mode: transition
 rl_dataloader:
@@ -118,7 +118,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: IPLComparisonOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 32
     mode: human
     eval: false

--- a/scripts/configs/hpl/discrete/metaworld.yaml
+++ b/scripts/configs/hpl/discrete/metaworld.yaml
@@ -79,16 +79,16 @@ network:
 
 rm_dataset:
   - class: MetaworldOfflineDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16 # [64, 128]
     capacity: 5000
   - class: MetaworldComparisonDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16
     capacity: 500
     segment_length: 24
   - class: MetaworldOfflineDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16 # [64, 128]
     capacity: 5000
 rm_dataloader:
@@ -97,7 +97,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: MetaworldOfflineDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16
     capacity: 5000
 rl_dataloader:
@@ -117,7 +117,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: MetaworldComparisonDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 32
     segment_length: 24
     capacity: 500

--- a/scripts/configs/hpl/gym.yaml
+++ b/scripts/configs/hpl/gym.yaml
@@ -76,17 +76,17 @@ network:
 
 rm_dataset:
   - class: D4RLOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 64 # [64, 128]
     mode: trajectory
     segment_length: 100
     padding_mode: none
   - class: IPLComparisonOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 8
     mode: human
   - class: D4RLOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 512
     mode: transition
 rm_dataloader:
@@ -95,7 +95,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: D4RLOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 512
     mode: transition
 rl_dataloader:
@@ -115,7 +115,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: IPLComparisonOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 32
     mode: human
     eval: false

--- a/scripts/configs/hpl/metaworld.yaml
+++ b/scripts/configs/hpl/metaworld.yaml
@@ -76,16 +76,16 @@ network:
 
 rm_dataset:
   - class: MetaworldOfflineDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16 # [64, 128]
     capacity: 5000
   - class: MetaworldComparisonDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16
     capacity: 500
     segment_length: 24
   - class: MetaworldOfflineDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16 # [64, 128]
     capacity: 5000
 rm_dataloader:
@@ -94,7 +94,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: MetaworldOfflineDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16
     capacity: 5000
 rl_dataloader:
@@ -114,7 +114,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: MetaworldComparisonDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 32
     segment_length: 24
     capacity: 500

--- a/scripts/configs/hpl/mismatch/bt_awac/default.yaml
+++ b/scripts/configs/hpl/mismatch/bt_awac/default.yaml
@@ -45,7 +45,7 @@ network:
 
 rm_dataset:
   - class: IPLComparisonOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 8
     segment_length: null
     mode: human
@@ -56,7 +56,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: D4RLOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 256
     mode: transition
     reward_normalize: true
@@ -77,7 +77,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: IPLComparisonOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 32
     mode: human
     eval: false

--- a/scripts/configs/hpl/mismatch/hpl_awac/default.yaml
+++ b/scripts/configs/hpl/mismatch/hpl_awac/default.yaml
@@ -70,17 +70,17 @@ network:
 
 rm_dataset:
   - class: D4RLOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 64 # [64, 128]
     mode: trajectory
     segment_length: 100
     padding_mode: none
   - class: IPLComparisonOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 8
     mode: human
   - class: D4RLOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 512
     mode: transition
 rm_dataloader:
@@ -89,7 +89,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: D4RLOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 512
     mode: transition
 rl_dataloader:
@@ -109,7 +109,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: IPLComparisonOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 32
     mode: human
     eval: false

--- a/scripts/configs/hpl/robomimic.yaml
+++ b/scripts/configs/hpl/robomimic.yaml
@@ -77,17 +77,17 @@ network:
 
 rm_dataset:
   - class: RobomimicDataset
-    env: Can-mh
+    env: <env>
     batch_size: 64 # [64, 128]
     mode: trajectory
     segment_length: 100
     padding_mode: none
   - class: IPLComparisonOfflineDataset
-    env: Can-mh
+    env: <env>
     batch_size: 8
     mode: human
   - class: RobomimicDataset
-    env: Can-mh
+    env: <env>
     batch_size: 256
     mode: transition
 rm_dataloader:
@@ -96,7 +96,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: RobomimicDataset
-    env: Can-mh
+    env: <env>
     batch_size: 256
     mode: transition
 rl_dataloader:
@@ -116,7 +116,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: IPLComparisonOfflineDataset
-    env: Can-mh
+    env: <env>
     batch_size: 32
     mode: human
     eval: false

--- a/scripts/configs/hpl_awac/discrete/adroit.yaml
+++ b/scripts/configs/hpl_awac/discrete/adroit.yaml
@@ -78,17 +78,17 @@ network:
 
 rm_dataset:
   - class: D4RLOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 64 # [64, 128]
     mode: trajectory
     segment_length: 100
     padding_mode: none
   - class: IPLComparisonOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 8
     mode: human
   - class: D4RLOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 512
     mode: transition
 rm_dataloader:
@@ -97,7 +97,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: D4RLOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 512
     mode: transition
 rl_dataloader:
@@ -117,7 +117,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: IPLComparisonOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 32
     mode: human
     eval: false

--- a/scripts/configs/hpl_awac/discrete/gym.yaml
+++ b/scripts/configs/hpl_awac/discrete/gym.yaml
@@ -78,17 +78,17 @@ network:
 
 rm_dataset:
   - class: D4RLOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 64 # [64, 128]
     mode: trajectory
     segment_length: 100
     padding_mode: none
   - class: IPLComparisonOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 8
     mode: human
   - class: D4RLOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 512
     mode: transition
 rm_dataloader:
@@ -97,7 +97,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: D4RLOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 512
     mode: transition
 rl_dataloader:
@@ -117,7 +117,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: IPLComparisonOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 32
     mode: human
     eval: false

--- a/scripts/configs/hpl_awac/discrete/metaworld.yaml
+++ b/scripts/configs/hpl_awac/discrete/metaworld.yaml
@@ -78,16 +78,16 @@ network:
 
 rm_dataset:
   - class: MetaworldOfflineDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16 # [64, 128]
     capacity: 5000
   - class: MetaworldComparisonDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16
     capacity: 500
     segment_length: 24
   - class: MetaworldOfflineDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16 # [64, 128]
     capacity: 5000
 rm_dataloader:
@@ -96,7 +96,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: MetaworldOfflineDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16
     capacity: 5000
 rl_dataloader:
@@ -116,7 +116,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: MetaworldComparisonDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 32
     segment_length: 24
     capacity: 500

--- a/scripts/configs/hpl_pomdp/discrete/gym.yaml
+++ b/scripts/configs/hpl_pomdp/discrete/gym.yaml
@@ -83,17 +83,17 @@ network:
 
 rm_dataset:
   - class: D4RLOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 64 # [64, 128]
     mode: trajectory
     segment_length: 100
     padding_mode: none
   - class: IPLComparisonOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 64
     mode: human
   - class: D4RLOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 512
     mode: transition
 rm_dataloader:
@@ -102,7 +102,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: D4RLOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 256
     mode: trajectory
     segment_length: 20
@@ -123,7 +123,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: IPLComparisonOfflineDataset
-    env: hopper-medium-expert-v2
+    env: <env>
     batch_size: 32
     mode: human
     eval: false

--- a/scripts/configs/ipl_awac/adroit.yaml
+++ b/scripts/configs/ipl_awac/adroit.yaml
@@ -44,12 +44,12 @@ network:
 
 dataset:
   - class: IPLComparisonOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 8
     mode: human
     segment_length: null
   - class: D4RLOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 256
     mode: transition
     reward_normalize: true

--- a/scripts/configs/ipl_awac/gym.yaml
+++ b/scripts/configs/ipl_awac/gym.yaml
@@ -48,12 +48,12 @@ network:
 
 dataset:
   - class: IPLComparisonOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 8
     mode: human
     segment_length: null
   - class: D4RLOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 256
     mode: transition
     reward_normalize: true

--- a/scripts/configs/ipl_awac/metaworld.yaml
+++ b/scripts/configs/ipl_awac/metaworld.yaml
@@ -48,12 +48,12 @@ network:
 
 dataset:
   - class: MetaworldComparisonDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16
     segment_length: null
     capacity: 500
   - class: MetaworldOfflineDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16
     capacity: 5000
 

--- a/scripts/configs/ipl_awac/metaworld/state_dense.yaml
+++ b/scripts/configs/ipl_awac/metaworld/state_dense.yaml
@@ -45,7 +45,7 @@ network:
 
 dataset:
   class: MetaworldComparisonOfflineDataset
-  env: mw_drawer-open-v2
+  env: <env>
   label_key: rl_sum
   segment_length: null
   batch_size: 96

--- a/scripts/configs/ipl_awac/metaworld/state_sparse.yaml
+++ b/scripts/configs/ipl_awac/metaworld/state_sparse.yaml
@@ -45,7 +45,7 @@ network:
 
 dataset:
   class: MetaworldComparisonOfflineDataset
-  env: mw_drawer-open-v2
+  env: <env>
   label_key: rl_sum
   segment_length: null
   batch_size: 96

--- a/scripts/configs/ipl_iql/adroit/default.yaml
+++ b/scripts/configs/ipl_iql/adroit/default.yaml
@@ -50,12 +50,12 @@ network:
 
 dataset:
   - class: IPLComparisonOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 8
     mode: human
     segment_length: null
   - class: D4RLOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 256
     mode: transition
     reward_normalize: true

--- a/scripts/configs/ipl_iql/gym/default.yaml
+++ b/scripts/configs/ipl_iql/gym/default.yaml
@@ -50,12 +50,12 @@ network:
 
 dataset:
   - class: IPLComparisonOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 8
     mode: human
     segment_length: null
   - class: D4RLOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 256
     mode: transition
     reward_normalize: true

--- a/scripts/configs/ipl_iql/metaworld/default.yaml
+++ b/scripts/configs/ipl_iql/metaworld/default.yaml
@@ -50,12 +50,12 @@ network:
 
 dataset:
   - class: MetaworldComparisonDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16
     segment_length: null
     capacity: 500
   - class: MetaworldOfflineDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16
     capacity: 5000
 

--- a/scripts/configs/ipl_iql/metaworld/state_dense.yaml
+++ b/scripts/configs/ipl_iql/metaworld/state_dense.yaml
@@ -47,7 +47,7 @@ network:
 
 dataset:
   class: MetaworldComparisonOfflineDataset
-  env: mw_drawer-open-v2
+  env: <env>
   label_key: rl_sum
   segment_length: null
   batch_size: 96

--- a/scripts/configs/ipl_iql/metaworld/state_sparse.yaml
+++ b/scripts/configs/ipl_iql/metaworld/state_sparse.yaml
@@ -47,7 +47,7 @@ network:
 
 dataset:
   class: MetaworldComparisonOfflineDataset
-  env: mw_drawer-open-v2
+  env: <env>
   label_key: rl_sum
   segment_length: null
   batch_size: 96

--- a/scripts/configs/mismatched_rpl/default.yaml
+++ b/scripts/configs/mismatched_rpl/default.yaml
@@ -57,12 +57,12 @@ network:
 
 dataset:
   - class: MismatchedComparisonDataset
-    env: HalfCheetah-gravity0.8
+    env: <env>
     batch_size: 96
     mode: trajectory
     segment_length: 64
   - class: MismatchedOfflineDataset
-    env: HalfCheetah-gravity1.2
+    env: <env>
     batch_size: 512
     mode: transition
 

--- a/scripts/configs/oracle_awac/metaworld/state_dense.yaml
+++ b/scripts/configs/oracle_awac/metaworld/state_dense.yaml
@@ -40,7 +40,7 @@ network:
 
 dataset:
   class: MetaworldComparisonOfflineDataset
-  env: mw_drawer-open-v2
+  env: <env>
   label_key: rl_sum
   segment_length: null
   batch_size: 96

--- a/scripts/configs/oracle_awac/metaworld/state_sparse.yaml
+++ b/scripts/configs/oracle_awac/metaworld/state_sparse.yaml
@@ -40,7 +40,7 @@ network:
 
 dataset:
   class: MetaworldComparisonOfflineDataset
-  env: mw_drawer-open-v2
+  env: <env>
   label_key: rl_sum
   segment_length: null
   batch_size: 96

--- a/scripts/configs/oracle_iql/metaworld/state_dense.yaml
+++ b/scripts/configs/oracle_iql/metaworld/state_dense.yaml
@@ -45,7 +45,7 @@ network:
 
 dataset:
   class: MetaworldComparisonOfflineDataset
-  env: mw_drawer-open-v2
+  env: <env>
   label_key: rl_sum
   segment_length: null
   batch_size: 96

--- a/scripts/configs/oracle_iql/metaworld/state_sparse.yaml
+++ b/scripts/configs/oracle_iql/metaworld/state_sparse.yaml
@@ -45,7 +45,7 @@ network:
 
 dataset:
   class: MetaworldComparisonOfflineDataset
-  env: mw_drawer-open-v2
+  env: <env>
   label_key: rl_sum
   segment_length: null
   batch_size: 96

--- a/scripts/configs/pt_awac/adroit.yaml
+++ b/scripts/configs/pt_awac/adroit.yaml
@@ -51,7 +51,7 @@ network:
 
 rm_dataset:
   - class: IPLComparisonOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 8
     mode: human
 rm_dataloader:
@@ -60,7 +60,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: D4RLOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 256
     mode: trajectory
     segment_length: 20
@@ -81,7 +81,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: IPLComparisonOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 32
     mode: human
     eval: false

--- a/scripts/configs/pt_awac/gym.yaml
+++ b/scripts/configs/pt_awac/gym.yaml
@@ -51,7 +51,7 @@ network:
 
 rm_dataset:
   - class: IPLComparisonOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 8
     segment_length: null
     mode: human
@@ -61,7 +61,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: D4RLOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 256
     mode: trajectory
     segment_length: 20
@@ -82,7 +82,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: IPLComparisonOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 32
     mode: human
     eval: false

--- a/scripts/configs/pt_awac/metaworld.yaml
+++ b/scripts/configs/pt_awac/metaworld.yaml
@@ -51,7 +51,7 @@ network:
 
 rm_dataset:
   - class: MetaworldComparisonDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16
     segment_length: null
     capacity: 500
@@ -61,7 +61,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: MetaworldOfflineDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16
     capacity: 5000
 rl_dataloader:
@@ -81,7 +81,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: MetaworldComparisonDataset
-    env: door-close-v2
+    env: <env>
     batch_size: 32
     segment_length: null
     capacity: 500

--- a/scripts/configs/pt_iql/adroit.yaml
+++ b/scripts/configs/pt_iql/adroit.yaml
@@ -56,7 +56,7 @@ network:
 
 rm_dataset:
   - class: IPLComparisonOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 64
     mode: human
 rm_dataloader:
@@ -65,7 +65,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: D4RLOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 256
     mode: trajectory
     segment_length: 20
@@ -86,7 +86,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: IPLComparisonOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 32
     mode: human
     eval: false

--- a/scripts/configs/pt_iql/gym.yaml
+++ b/scripts/configs/pt_iql/gym.yaml
@@ -56,7 +56,7 @@ network:
 
 rm_dataset:
   - class: IPLComparisonOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 64
     segment_length: null
     mode: human
@@ -66,7 +66,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: D4RLOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 256
     mode: trajectory
     segment_length: 20
@@ -87,7 +87,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: IPLComparisonOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 32
     mode: human
     eval: false

--- a/scripts/configs/pt_iql/metaworld.yaml
+++ b/scripts/configs/pt_iql/metaworld.yaml
@@ -56,7 +56,7 @@ network:
 
 rm_dataset:
   - class: MetaworldComparisonDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 64
     segment_length: null
     capacity: 500
@@ -66,7 +66,7 @@ rm_dataloader:
 
 rl_dataset:
   - class: MetaworldOfflineDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 16
     capacity: 5000
 rl_dataloader:
@@ -86,7 +86,7 @@ rm_eval:
   function: eval_reward_model
   eval_dataset_kwargs:
     class: MetaworldComparisonDataset
-    env: door-close-v2
+    env: <env>
     batch_size: 32
     segment_length: null
     capacity: 500

--- a/scripts/configs/sft/adroit.yaml
+++ b/scripts/configs/sft/adroit.yaml
@@ -30,7 +30,7 @@ network:
 
 dataset:
     class: IPLComparisonOfflineDataset
-    env: pen-cloned-v1
+    env: <env>
     batch_size: 64
     segment_length: null
     mode: human

--- a/scripts/configs/sft/gym.yaml
+++ b/scripts/configs/sft/gym.yaml
@@ -30,7 +30,7 @@ network:
 
 dataset:
     class: IPLComparisonOfflineDataset
-    env: hopper-medium-replay-v2
+    env: <env>
     batch_size: 64
     segment_length: null
     mode: human

--- a/scripts/configs/sft/metaworld.yaml
+++ b/scripts/configs/sft/metaworld.yaml
@@ -30,7 +30,7 @@ network:
 
 dataset:
     class: MetaworldComparisonDataset
-    env: button-press-v2
+    env: <env>
     batch_size: 64
     segment_length: null
     capacity: 500

--- a/scripts/configs/sft/metaworld/state_dense.yaml
+++ b/scripts/configs/sft/metaworld/state_dense.yaml
@@ -35,7 +35,7 @@ network:
 
 dataset:
   class: MetaworldComparisonOfflineDataset
-  env: mw_drawer-open-v2
+  env: <env>
   label_key: rl_sum
   segment_length: null
   batch_size: 96

--- a/scripts/configs/sft/metaworld/state_sparse.yaml
+++ b/scripts/configs/sft/metaworld/state_sparse.yaml
@@ -35,7 +35,7 @@ network:
 
 dataset:
   class: MetaworldComparisonOfflineDataset
-  env: mw_drawer-open-v2
+  env: <env>
   label_key: rl_sum
   segment_length: null
   batch_size: 96

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -10,9 +10,10 @@ import wandb
 import wiserl.algorithm
 from wiserl.env import get_env
 from wiserl.trainer.offline_trainer import OfflineTrainer
+from wiserl.utils.utils import use_placeholder
 
 if __name__ == "__main__":
-    args = parse_args(convert=False)
+    args = parse_args(convert=False, post_init=use_placeholder)
     name_prefix = f"{args['algorithm']['class']}/{args['name']}/{args['env']}"
     logger = CompositeLogger(
         log_dir=f"./log/{name_prefix}",

--- a/scripts/rmb_main.py
+++ b/scripts/rmb_main.py
@@ -10,9 +10,10 @@ import wandb
 import wiserl.algorithm
 from wiserl.env import get_env
 from wiserl.trainer.rmb_offline_trainer import RewardModelBasedOfflineTrainer
+from wiserl.utils.utils import use_placeholder
 
 if __name__ == "__main__":
-    args = parse_args(convert=False)
+    args = parse_args(convert=False, post_init=use_placeholder)
     name_prefix = f"{args['algorithm']['class']}/{args['name']}/{args['env']}"
     logger = CompositeLogger(
         log_dir=f"./log/{name_prefix}",


### PR DESCRIPTION
We can achieve a simpler configuration method like:

```yaml
rm_dataset:
  - class: D4RLOfflineDataset
    env: <env>
    batch_size: 64 # [64, 128]
    mode: trajectory
    segment_length: 100
    padding_mode: none
  - class: IPLComparisonOfflineDataset
    env: <env>
    batch_size: 8
    mode: human
  - class: D4RLOfflineDataset
    env: <env>
    batch_size: 512
    mode: transition
```

We only need to set `--env hopper-medium-replay-v2` to switch the environment for all datasets.